### PR TITLE
remove qt 6.0.4 from conandata.yml

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -1,12 +1,4 @@
 sources:
-  "6.0.4":
-    url:
-      - "https://download.qt.io/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
-      - "https://qt-mirror.dannhauer.de/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
-      - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
-      - "https://ftp.fau.de/qtproject/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
-      - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
-    sha256: "677db6472420f9046b16f7c0d0aa15c4f11f344462a6374feb860625c12fc72b"
   "6.1.3":
     url:
       - "https://download.qt.io/archive/qt/6.1/6.1.3/single/qt-everywhere-src-6.1.3.tar.xz"
@@ -40,9 +32,6 @@ sources:
       - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/6.3/6.3.1/single/qt-everywhere-src-6.3.1.tar.xz"
     sha256: "51114e789485fdb6b35d112dfd7c7abb38326325ac51221b6341564a1c3cc726"
 patches:
-  "6.0.4":
-    - base_path: "qt6/qtbase/cmake"
-      patch_file: "patches/qt6-pri-helpers-fix.diff"
   "6.1.3":
     - base_path: "qt6/qtdeclarative"
       patch_file: "patches/32451d5.diff"


### PR DESCRIPTION
it was removed from config.yml in https://github.com/conan-io/conan-center-index/commit/1536fa7dfbef95ba47f4ac2068f5d7ac51e8a7e8#diff-9a7b2cfc0b637d7ede086317d1cf51b49481addacaba8a80aafc2f1be208f366